### PR TITLE
Bug 23625: ArticleRequestsMandatoryFields* only affects field labels,…

### DIFF
--- a/koha-tmpl/opac-tmpl/bootstrap/en/modules/opac-request-article.tt
+++ b/koha-tmpl/opac-tmpl/bootstrap/en/modules/opac-request-article.tt
@@ -36,64 +36,71 @@
                         <li>
                             [% IF mandatory_fields.search('title') %]
                                 <label for="title" class="required">Title:</label>
+                                <input type="text" required name="title" id="title" size="50"/>
                             [% ELSE %]
                                 <label for="title">Title:</label>
+                                <input type="text" name="title" id="title" size="50"/>
                             [% END %]
-                            <input type="text" name="title" id="title" size="50"/>
                         </li>
 
                         <li>
                             [% IF mandatory_fields.search('author') %]
                                 <label for="author" class="required">Author:</label>
+                                <input type="text" required name="author" id="author" size="50"/>
                             [% ELSE %]
                                 <label for="author">Author:</label>
+                                <input type="text" name="author" id="author" size="50"/>
                             [% END %]
-                            <input type="text" name="author" id="author" size="50"/>
                         </li>
 
                         <li>
                             [% IF mandatory_fields.search('volume') %]
                                 <label for="volume" class="required">Volume:</label>
+                                <input type="text" required name="volume" id="volume" size="50"/>
                             [% ELSE %]
                                 <label for="volume">Volume:</label>
+                                <input type="text" name="volume" id="volume" size="50"/>
                             [% END %]
-                            <input type="text" name="volume" id="volume" size="50"/>
                         </li>
 
                         <li>
                             [% IF mandatory_fields.search('issue') %]
                                 <label for="issue" class="required">Issue:</label>
+                                <input type="text" required name="issue" id="issue" size="50"/>
                             [% ELSE %]
                                 <label for="issue">Issue:</label>
+                                <input type="text" name="issue" id="issue" size="50"/>
                             [% END %]
-                            <input type="text" name="issue" id="issue" size="50"/>
                         </li>
 
                         <li>
                             [% IF mandatory_fields.search('date') %]
                                 <label for="date" class="required">Date:</label>
+                                <input type="text" required name="date" id="date" size="50"/>
                             [% ELSE %]
                                 <label for="date">Date:</label>
+                                <input type="text" name="date" id="date" size="50"/>
                             [% END %]
-                            <input type="text" name="date" id="date" size="50"/>
                         </li>
 
                         <li>
                             [% IF mandatory_fields.search('pages') %]
                                 <label for="pages" class="required">Pages:</label>
+                                <input type="text" name="pages" id="pages" size="50"/>
                             [% ELSE %]
                                 <label for="pages">Pages:</label>
+                                <input type="text" name="pages" id="pages" size="50"/>
                             [% END %]
-                            <input type="text" name="pages" id="pages" size="50"/>
                         </li>
 
                         <li>
                             [% IF mandatory_fields.search('chapters') %]
                                 <label for="chapters" class="required">Chapters:</label>
+                                <input type="text" name="chapters" id="chapters" size="50"/>
                             [% ELSE %]
                                 <label for="chapters">Chapters:</label>
+                                <input type="text" name="chapters" id="chapters" size="50"/>
                             [% END %]
-                            <input type="text" name="chapters" id="chapters" size="50"/>
                         </li>
 
                         <li>


### PR DESCRIPTION
… does not make inputs required

Test plan:

1. Enable article requests ( syspref: ArticleRequests => Enable, Circ and fine rules ALL/ALL (or a given category/itemtype): Article requests => Yes )
2. Set one or more fields to require in the ArticleRequestsMandatoryFields, ArticleRequestsMandatoryFieldsItemOnly, and/or ArticleRequestsMandatoryFieldsRecordOnly settings (all these settings are affected in the same manner)
3. Search for a title and select the "Request Article" button from the OPAC search results
4. Authenticate as a patron
5. Neglect to fill out at least one of the mandatory fields
6. Select the "Place Request" button at the bottom of the form
7. The form submits despite the empty mandatory fields
8. Apply patch
9. Repeat steps 3, 5, & 6
10 . The form should refuse to submit, show a browser-native message about the missing required fields.